### PR TITLE
PowCache Support Part 2

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -177,17 +177,19 @@ void BaseIndex::ThreadSync()
                 // No need to handle errors in Commit. See rationale above.
                 Commit();
             }
-
-            CBlock block;
-            if (!ReadBlockFromDisk(block, pindex, consensus_params)) {
-                FatalError("%s: Failed to read block %s from disk",
-                           __func__, pindex->GetBlockHash().ToString());
-                return;
-            }
-            if (!WriteBlock(block, pindex)) {
-                FatalError("%s: Failed to write block %s to index database",
-                           __func__, pindex->GetBlockHash().ToString());
-                return;
+            {
+                LOCK(cs_main);
+                CBlock block;
+                if (!ReadBlockFromDisk(block, pindex, consensus_params)) {
+                    FatalError("%s: Failed to read block %s from disk",
+                               __func__, pindex->GetBlockHash().ToString());
+                    return;
+                }
+                if (!WriteBlock(block, pindex)) {
+                    FatalError("%s: Failed to write block %s to index database",
+                               __func__, pindex->GetBlockHash().ToString());
+                    return;
+                }
             }
         }
     }

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -30,18 +30,17 @@ uint256 CBlockHeader::GetPOWHash(bool readCache) const
     uint256 powHash;
     bool found = false;
 
-    LOCK(cs_pow);
     if (readCache) {
         found = cache.get(headerHash, powHash);
     }
 
-    if (!found || cache.IsValidate()) {
+    if (!found || cache.GetValidate()) {
         uint256 powHash2 = ComputeHash();
         if (found && powHash2 != powHash) {
-            LogPrintf("PowCache failure: headerHash: %s, from cache: %s, computed: %s, correcting\n", headerHash.ToString(), powHash.ToString(), powHash2.ToString());
+            // We cannot use the loggers at this level
+            std::cerr << "PowCache failure: headerHash: " << headerHash.ToString() << ", from cache: " << powHash.ToString() << ", computed: " << powHash2.ToString() << ", correcting" << std::endl;
         }
         cache.insert(headerHash, powHash2);
-        cache.DoMaintenance();
     }
     return powHash;
 }

--- a/src/primitives/powcache.h
+++ b/src/primitives/powcache.h
@@ -11,14 +11,15 @@
 #include <util/system.h>
 #include <util/unordered_lru_cache.h>
 
-extern RecursiveMutex cs_pow;
-
 /// @brief Maximum size of cache, in elements
 static const int64_t DEFAULT_POWCACHE_MAX_ELEMENTS  = 1000000;
 /// @brief Save after this many new elements
 static const int     DEFAULT_POWCACHE_SAVE_INTERVAL = 720;
 /// @brief Validate every PowCache entry before use (for testing)
 static bool          DEFAULT_POWCACHE_VALIDATE      = false;
+/// @brief PowCache current serialization version
+static const int     POWCACHE_CURRENT_VERSION       = 1;
+
 
 class CPowCache : public unordered_lru_cache<uint256, uint256, std::hash<uint256>>
 {
@@ -26,33 +27,32 @@ private:
     static CPowCache* instance;
     static const int CURRENT_VERSION = 1;
 
-    int    nVersion;
-    size_t nSavedSize;
-    int    nSaveInterval;
-    bool   bValidate;
+    int      nVersion;
+    size_t   nSavedSize;
+    int      nSaveInterval;
+    bool     bValidate;
 
 public:
     static CPowCache& Instance();
 
-    CPowCache(int64_t maxElements = DEFAULT_POWCACHE_MAX_ELEMENTS, bool validate = DEFAULT_POWCACHE_VALIDATE, int64_t saveInterval = DEFAULT_POWCACHE_SAVE_INTERVAL);
+    CPowCache();
     virtual ~CPowCache();
 
-    void Clear();
-    void CheckAndRemove();
-    bool IsValidate() const { return bValidate; }
-    void Load();
-    void Save();
-    void DoMaintenance();
+    void SetMaxElements(int64_t maxElements);
+    void SetValidate(int64_t validate);
+    void SetSaveInterval(int64_t saveInterval);
+
+    bool GetValidate() const { return bValidate; }
+    bool WantsToSave() const;
 
     std::string ToString() const;
 
-    template<typename Stream> void Serialize(Stream& s) { this->SerializationOp(s, CSerActionSerialize()); }
+    template<typename Stream> void Serialize(Stream& s)   { SerializationOp(s, CSerActionSerialize());   }
     template<typename Stream> void Unserialize(Stream& s) { SerializationOp(s, CSerActionUnserialize()); }
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        LOCK(cs_pow);
         READWRITE(nVersion);
 
         uint64_t cacheSize = size();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1398,7 +1398,7 @@ void CChainState::InvalidChainFound(CBlockIndex* pindexNew)
 
     LogPrintf("%s: invalid block=%s  height=%d  log2_trust=%.8g  moneysupply=%s  date=%s  moneysupply=%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
-      log(pindexNew->nChainTrust.getdouble())/log(2.0), 
+      log(pindexNew->nChainTrust.getdouble())/log(2.0),
       FormatMoney(m_chain.Tip()->nMoneySupply),
       FormatISO8601DateTime(pindexNew->GetBlockTime()),
       FormatMoney(pindexNew->nMoneySupply));
@@ -4134,6 +4134,7 @@ void CChainState::LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp)
                 std::deque<uint256> queue;
                 queue.push_back(hash);
                 while (!queue.empty()) {
+                    LOCK(cs_main);
                     uint256 head = queue.front();
                     queue.pop_front();
                     std::pair<std::multimap<uint256, FlatFilePos>::iterator, std::multimap<uint256, FlatFilePos>::iterator> range = mapBlocksUnknownParent.equal_range(head);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2107,7 +2107,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
                              strprintf("CheckBlock() : coinstake reward exceeded %s > %s",
                                        FormatMoney(nStakeReward),
                                        FormatMoney(blockReward)));
-    
+
     if (block.vtx[0]->GetValueOut() > (block.IsProofOfWork() ? blockReward : 0))
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-amount",
                              strprintf("CheckBlock() : coinbase reward exceeded %s > %s",
@@ -4150,7 +4150,6 @@ void CChainState::LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp)
                         if (ReadBlockFromDisk(*pblockrecursive, it->second, m_params.GetConsensus())) {
                             LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, pblockrecursive->GetHash().ToString(),
                                     head.ToString());
-                            LOCK(cs_main);
                             BlockValidationState dummy;
                             if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr)) {
                                 nLoaded++;


### PR DESCRIPTION
Restructured PowCache to remove locks, logging, and file I/O.

Moved logging and file I/O into Init.

cs_main is locked by all callers (except two, which were added).

This removes link dependencies from libconsensus.
