### PR TITLE
pow cache patch

### DIFF
--- a/src/pow.h
+++ b/src/pow.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+class CBlock;
 class CBlockHeader;
 class CBlockIndex;
 class uint256;
@@ -20,5 +21,6 @@ unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfS
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);
+bool CheckPOW(const CBlock& block, const Consensus::Params& consensusParams);
 
 #endif // BITCOIN_POW_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -40,6 +40,8 @@ uint256 CBlockHeader::GetPOWHash(bool readCache) const
             // We cannot use the loggers at this level
             std::cerr << "PowCache failure: headerHash: " << headerHash.ToString() << ", from cache: " << powHash.ToString() << ", computed: " << powHash2.ToString() << ", correcting" << std::endl;
         }
+        powHash = powHash2;
+        cache.erase(headerHash); // If it exists, replace it
         cache.insert(headerHash, powHash2);
     }
     return powHash;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3105,7 +3105,7 @@ void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pi
 static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetPOWHash(), block.nBits, consensusParams))
+    if (fCheckPOW && !CheckPOW(block, consensusParams))
         return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "proof of work failed");
 
     return true;


### PR DESCRIPTION
fix GetPOWHash returning null hash if the hash is not on the cache
moved CheckPOW to make it available on validation.cpp
changed CheckProofOfWork to CheckPOW on CheckBlockHeader
moved a misplaced CheckPOW on blockstorage.cpp